### PR TITLE
Product demo overflow issue fixed

### DIFF
--- a/Frontend/src/CSS/ProductDetail.css
+++ b/Frontend/src/CSS/ProductDetail.css
@@ -38,13 +38,16 @@
   margin-top: -5rem;
   flex: 1;
   text-align: center;
+  height: 100%;
   /* border: 2px so lid red; */
 }
 
 .product-detail-image {
-  max-width: 45%;
-  max-height: 60%;
+  max-width: 80%;
+  max-height: 80%;
   /* display: none; */
+  position: relative;
+  top: 2em;
   border: 3px solid var(--color-6);
   border-radius: 25px;
   box-shadow: 10px 10px 0px rgba(101, 3, 3, 0.2);
@@ -178,32 +181,36 @@
   flex-direction: row;
   align-items: center;
   position: relative;
-  bottom: -70px;
-  gap: 20px;
-  margin-left: 100px;
+  bottom: -6em;
+  gap: 4%;
+  /* margin-left: 100px; */
+  flex-wrap: wrap;
+  left: -0.5em;
+  justify-content: center;
+  row-gap: 1em;
 }
 
 .product-review-card {
   background-color: #fff;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   border-radius: 5px;
-  padding: 20px;
-  margin: 10px 0;
+  padding: 3%;
   text-align: center;
-  width: 40%;
+  word-wrap: break-word;
+  /* width: max-content; */
 }
 
 .customer-name {
   font-family: var(--font-2);
-  font-size: 16px;
+  font-size: 90%;
   color: var(--color-6);
   margin-bottom: 5px;
 }
 
 .rating {
   font-family: var(--font-1);
-  font-size: 20px;
-  color: gold; 
+  font-size: 80%;
+  color: gold;
 }
 
 

--- a/Frontend/src/CSS/ProductDetail.css
+++ b/Frontend/src/CSS/ProductDetail.css
@@ -181,7 +181,7 @@
   flex-direction: row;
   align-items: center;
   position: relative;
-  bottom: -6em;
+  bottom: -3.5em;
   gap: 4%;
   /* margin-left: 100px; */
   flex-wrap: wrap;
@@ -194,7 +194,7 @@
   background-color: #fff;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   border-radius: 5px;
-  padding: 3%;
+  padding: 2%;
   text-align: center;
   word-wrap: break-word;
   /* width: max-content; */


### PR DESCRIPTION
# Issue #65 fixed

## Fix made:
The demo description was overflowing from the Demo icon.
Fixed the issue by changing the position of the product-detail-reviews and product-review-card class, and customer-name and rating class.

## Before Change:
<img width="1470" alt="Screenshot 2024-05-10 at 11 13 43 PM" src="https://github.com/harshalhonde21/EcommerceSpectastyle/assets/115504480/f961cffb-8feb-4551-9fd4-a9c54a714a13">

## After Change:
<img width="1470" alt="Screenshot 2024-05-11 at 1 31 15 PM" src="https://github.com/harshalhonde21/EcommerceSpectastyle/assets/115504480/95561957-73a4-4bcf-bb9b-93f1ad5b0211">
<img width="1470" alt="Screenshot 2024-05-11 at 1 31 29 PM" src="https://github.com/harshalhonde21/EcommerceSpectastyle/assets/115504480/11589cd9-ae14-44a1-a11d-7532dbccf1c7">
<img width="1470" alt="Screenshot 2024-05-11 at 1 31 41 PM" src="https://github.com/harshalhonde21/EcommerceSpectastyle/assets/115504480/34ed0b5f-ecd6-4290-a8be-8478a87f8c61">
