### PR TITLE
Duplicate Entry of name is deleted from contact form

### DIFF
--- a/Frontend/src/Pages/Contact.jsx
+++ b/Frontend/src/Pages/Contact.jsx
@@ -111,23 +111,6 @@ const Contact = () => {
                   fontSize: "16px", // Font size set to 16px
                   padding: "10px", // Padding set to 10px
                 }}
-                type="text"
-                id="name"
-                name="name"
-                placeholder="Good Name"
-                required
-              />
-            </div>
-            <div className="form-group">
-              <input
-                style={{
-                  width: "100%",
-                  marginBottom: "-2rem",
-                  border: "2px solid rgb(70, 11, 70)",
-                  borderRadius: "8px",
-                  fontSize: "16px", // Font size set to 16px
-                  padding: "10px", // Padding set to 10px
-                }}
                 type="email"
                 id="email"
                 name="email"


### PR DESCRIPTION
Solved Issue No. #146. Removed Duplicate Entry of name from contact form. Please merge this  @harshalhonde21
![Screenshot 2024-05-14 121053](https://github.com/harshalhonde21/EcommerceSpectastyle/assets/108013711/3770aa6d-a568-4cde-a6be-3a5fa06191bb)
